### PR TITLE
fix headers CAKEPHP --> passbolt_session

### DIFF
--- a/lib/gpg_auth.php
+++ b/lib/gpg_auth.php
@@ -188,7 +188,7 @@ class GpgAuth
         }
 
         $cookieHeader = $this->_getHeader($header, 'Set-Cookie');
-        preg_match_all('/CAKEPHP=([^;]*);/mi', $cookieHeader, $matches);
+        preg_match_all('/passbolt_session=([^;]*);/mi', $cookieHeader, $matches);
         $this->sessionId = $matches[1][0];
     }
 
@@ -214,7 +214,7 @@ class GpgAuth
 
     public function getCookie(bool $addCsrfToken = false)
     {
-        $cookie = "CAKEPHP={$this->sessionId}; path=/; HttpOnly;";
+        $cookie = "passbolt_session={$this->sessionId}; path=/; HttpOnly;";
         if ($addCsrfToken) {
             $cookie .= " csrfToken={$this->getCsrfToken()}";
         }


### PR DESCRIPTION
With Ubuntu 22.04.LTS, we have passbolt-ce-server Version: 4.5.2-1

When we try to GpgAuth->login(), cookie headers are not CAKE_PHP but 'passbolt_session'

That is why we receive an error message "Authentication is required to continue"

This merge request use recent headers and login is working.  
